### PR TITLE
Update dependencies versions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["transform-runtime", "transform-async-to-generator"]
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  },
+  "plugins": ["add-module-exports"],
+  "presets": ["es2015-node", "stage-3"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.nyc_output
 /node_modules
 /test/coverage
 /test/knexfile.js

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,9 @@
+{
+  "instrument": false,
+  "report-dir": "test/coverage",
+  "reporter": [
+    "html",
+    "text-summary"
+  ],
+  "sourceMap": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ before_script:
   - psql -U postgres -c 'create database "bookshelf-mask";'
 
 node_js:
-  - "0.10"
   - "4"
   - "5"
+  - "6"
 
 after_success:
   - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -26,13 +26,12 @@
     "visibility"
   ],
   "options": {
-    "isparta": "--dir test/coverage",
-    "mocha": "--compilers js:babel-register --bail --require should test/index.js"
+    "mocha": "--compilers js:babel-register --bail --require should test"
   },
   "scripts": {
     "build": "rm -rf dist && babel src --out-dir dist",
     "changelog": "github_changelog_generator --bug-labels --enhancement-labels --header-label='# Changelog'",
-    "cover": "babel-node node_modules/.bin/isparta cover $npm_package_options_isparta _mocha -- $npm_package_options_mocha",
+    "cover": "NODE_ENV=test nyc mocha $npm_package_options_mocha",
     "coveralls": "npm run cover && cat ./test/coverage/lcov.info | coveralls",
     "lint": "git diff --cached --name-only --diff-filter=ACMRTUXB | grep -E '\\.(js)(\\..+)?$' | xargs eslint",
     "test": "mocha $npm_package_options_mocha"
@@ -44,29 +43,25 @@
     "bookshelf": ">= 0.7"
   },
   "devDependencies": {
-    "babel-cli": "^6.7.5",
-    "babel-eslint": "^6.0.2",
-    "babel-plugin-transform-async-to-generator": "^6.8.0",
-    "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-register": "^6.7.2",
-    "babel-runtime": "^6.9.2",
-    "bookshelf": "^0.9.5",
-    "coveralls": "^2.11.9",
-    "eslint": "^2.8.0",
-    "eslint-config-seegno": "^4.0.0",
-    "eslint-plugin-babel": "^3.2.0",
-    "eslint-plugin-sort-class-members": "^1.0.1",
-    "isparta": "^4.0.0",
-    "knex": "^0.11.7",
-    "mocha": "^2.4.5",
-    "pg": "^6.0.0",
-    "pre-commit": "^1.1.2",
-    "should": "^8.3.1"
+    "babel-cli": "6.18.0",
+    "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-istanbul": "2.0.3",
+    "babel-preset-es2015-node": "4.0.2",
+    "babel-preset-stage-3": "6.17.0",
+    "babel-register": "6.18.0",
+    "bookshelf": "0.10.2",
+    "coveralls": "2.11.14",
+    "eslint": "3.8.1",
+    "eslint-config-seegno": "8.0.0",
+    "knex": "0.12.6",
+    "mocha": "3.1.2",
+    "nyc": "8.3.2",
+    "pg": "6.1.0",
+    "pre-commit": "1.1.3",
+    "should": "11.1.1"
   },
   "engines": {
-    "iojs": ">= 1",
-    "node": ">= 0.10"
+    "node": ">= 4"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
This PR updates all dependencies versions, which includes:
- Replace **isparta** with **nyc**;
- Update `cover` script to use _nyc_;
- Update **babel** plugins;
- Update **babel** configuration;
- Remove deprecated **eslint** plugins;
- Remove support below Node.js v4;
