### PR TITLE
Update mask prototype property to class property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,18 @@ var mask = require('bookshelf-mask');
 bookshelf.plugin(mask);
 ```
 
-Define masks on your models with `masks` prototype property:
+Define masks on your models with `masks` class property:
 
 ```js
 var Author = bookshelf.Model.extend({
-  masks: {
-    custom: 'id,name'
-  },
   posts: {
     return this.hasMany(Post);
   },
   tableName: 'Author'
+}, {
+  masks: {
+    custom: 'id,name'
+  }
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,13 @@ import mask from 'json-mask';
 export default Bookshelf => {
   Bookshelf.Model = Bookshelf.Model.extend({
     mask(scope, options) {
-      return mask(this.toJSON(options), this.masks && this.masks[scope] || scope);
+      return mask(this.toJSON(options), this.constructor.masks && this.constructor.masks[scope] || scope);
     }
   });
 
   Bookshelf.Collection = Bookshelf.Collection.extend({
     mask(scope, options) {
-      scope = this.model.prototype.masks && this.model.prototype.masks[scope] || scope;
+      scope = this.model.masks && this.model.masks[scope] || scope;
 
       return this.toJSON(options).map(model => mask(model, scope));
     }

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -45,10 +45,11 @@ export function dropTables(repository) {
 
 export function fixtures(repository) {
   const Post = repository.Model.extend({
+    tableName: 'Post'
+  }, {
     masks: {
       private: 'foo'
-    },
-    tableName: 'Post'
+    }
   });
 
   const Author = repository.Model.extend({


### PR DESCRIPTION
This updates the `masks` option to be a class property instead of prototype property, since such option should not be part of model instances properties.

This is considered a bugfix since it should have been introduced as breaking change with [2.0.0](https://github.com/seegno/bookshelf-mask/releases/tag/2.0.0), and therefore released as [2.0.1](https://github.com/seegno/bookshelf-mask/releases/tag/2.0.1).
